### PR TITLE
Remove endpoints exposing build logs

### DIFF
--- a/moldavite/api_v1.py
+++ b/moldavite/api_v1.py
@@ -22,7 +22,6 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import Tuple
-from typing import Union
 
 import datetime
 from dateutil.parser import parse as datetime_parser
@@ -258,25 +257,6 @@ def delete_jupyterbook(book_id: str) -> Tuple[Dict[str, str], int]:
     return {"book_id": book_id}, 201
 
 
-def get_jupyterbook_log(
-    book_id: str,
-) -> Tuple[Dict[str, Union[str, Dict[str, str]]], int]:
-    """Get logs of the given JupyterBook workflow."""
-    log = {}
-
-    # XXX: eventually logs from other containers to help with issues debugging (e.g. wrong Git branch)
-    try:
-        log["build-book"] = _OPENSHIFT.get_workflow_node_log(
-            node_name="build-book",
-            workflow_id=book_id,
-            namespace=Configuration.BUILD_NAMESPACE,
-        )
-    except NotFoundExceptionError:
-        return {"error": f"No book with id {book_id!r} found"}, 404
-
-    return {"log": log}, 200
-
-
 def post_jupyterhub_build(specification: Dict[str, Any]) -> Tuple[Dict[str, str], int]:
     """Create a JupyterHub build request."""
     repo_url = specification["repo_url"].strip()
@@ -355,22 +335,3 @@ def delete_jupyterhub(notebook_id: str) -> Tuple[Dict[str, str], int]:
         )
 
     return {"notebook_id": notebook_id}, 201
-
-
-def get_jupyterhub_log(
-    notebook_id: str,
-) -> Tuple[Dict[str, Union[str, Dict[str, str]]], int]:
-    """Get logs of the given JupyterHub NoteBook workflow."""
-    log = {}
-
-    # XXX: eventually logs from other containers to help with issues debugging (e.g. wrong Git branch)
-    try:
-        log["build-book"] = _OPENSHIFT.get_workflow_node_log(
-            node_name="build-book",
-            workflow_id=notebook_id,
-            namespace=Configuration.BUILD_NAMESPACE,
-        )
-    except NotFoundExceptionError:
-        return {"error": f"No notebook with id {notebook_id!r} found"}, 404
-
-    return {"log": log}, 200

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -65,26 +65,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/JupyterBookStatusResponse'
 
-  /book/{book_id}/log:
-    get:
-      tags:
-        - Book
-      x-openapi-router-controller: moldavite.api_v1
-      operationId: get_jupyterbook_log
-      summary: Get log of JupyterBook build process.
-      parameters:
-        - name: book_id
-          in: path
-          required: true
-          description: A unique identifier of the JupyterBook.
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response with book build status.
-        '404':
-          description: The given book was not found.
-
   /book/{book_id}:
     delete:
       tags:
@@ -147,26 +127,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JupyterHubStatusResponse'
-
-  /notebook/{notebook_id}/log:
-    get:
-      tags:
-        - NoteBook
-      x-openapi-router-controller: moldavite.api_v1
-      operationId: get_jupyterhub_log
-      summary: Get log of JupyterHub NoteBook build process.
-      parameters:
-        - name: notebook_id
-          in: path
-          required: true
-          description: A unique identifier of the JupyterHub NoteBook.
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response with notebook build status.
-        '404':
-          description: The given notebook was not found.
 
   /notebook/{notebook_id}:
     delete:


### PR DESCRIPTION
## This introduces a breaking change

- [x] Yes

## This Pull Request implements

As builds are done in tekton pipelines, there is no need to expose logs on endpoints. We could eventually point users to the OpenShift console to be compatible with Meteor.