### PR TITLE
Remove arguments related to Ceph

### DIFF
--- a/moldavite/api_v1.py
+++ b/moldavite/api_v1.py
@@ -126,7 +126,7 @@ def post_jupyterbook_build(specification: Dict[str, Any]) -> Tuple[Dict[str, str
             "MOLDAVITE_BOOK_PATH": book_path,
             "MOLDAVITE_TTL": ttl,
         },
-        workflow_parameters=_OPENSHIFT._assign_workflow_parameters_for_ceph(),  # XXX: remove private call
+        workflow_parameters={},
         workflow_namespace=Configuration.BUILD_NAMESPACE,
     )
 

--- a/openshift/moldavite-jupyterhub-build.yaml
+++ b/openshift/moldavite-jupyterhub-build.yaml
@@ -35,15 +35,6 @@ objects:
     - name: output-volume
       emptyDir: {}
 
-    arguments:
-      parameters:
-      - name: notebook_id
-        value: "${MOLDAVITE_NOTEBOOK_ID}"
-      - name: ceph_bucket_prefix
-      - name: ceph_bucket_name
-      - name: ceph_host
-      - name: deployment_name
-
     templates:
     - name: jupyterhub-notebook-build-book
       steps:

--- a/openshift/moldavite.yaml
+++ b/openshift/moldavite.yaml
@@ -52,36 +52,6 @@ spec:
                 configMapKeyRef:
                   key: app-secret
                   name: moldavite
-            - name: THOTH_DEPLOYMENT_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: deployment-name
-                  name: thoth
-            - name: THOTH_S3_ENDPOINT_URL
-              valueFrom:
-                configMapKeyRef:
-                  key: host
-                  name: ceph
-            - name: THOTH_CEPH_BUCKET
-              valueFrom:
-                configMapKeyRef:
-                  key: bucket-name
-                  name: ceph
-            - name: THOTH_CEPH_BUCKET_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  key: bucket-prefix
-                  name: ceph
-            - name: THOTH_CEPH_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: ceph
-                  key: key-id
-            - name: THOTH_CEPH_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ceph
-                  key: secret-key
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

... it looks to me they are not used in the workflow. Also, `notebook_id` workflow parameter can be removed as OpenShift template parameters are used.
